### PR TITLE
init commit

### DIFF
--- a/A1R3/MoistureDataStream
+++ b/A1R3/MoistureDataStream
@@ -1,0 +1,14 @@
+const int soilMoisturePin = A0;
+
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  int sensorValue = analogRead(soilMoisturePin);
+
+  Serial.print("Soil Moisture Level (0-1023): ");
+  Serial.println(sensorValue);
+
+  delay(1000);
+}


### PR DESCRIPTION
5V is passed into the sensor's board from the Arduino's 5V port.

The AO pin on the Arduino board is assigned to the field soilMoisturePin. The access modifier const in C++ acts similarly to final in Java; the assignment of AO to soilMoisturePin cannot be changed once set.

In the setup method, the serial connection to the Arduino board is set to a rate of 9600 bits per second.

In the loop method, the soilMoisturePin data is passed through analogRead, which returns a discrete digital value between 0 (wettest) and 1023 (dryest)--representing a voltage reading from 0V to 5V at the A0 port from the moisture sensor--and stores the value to sensorValue. The value is then printed with a prompt, each output prompt delayed by 1000 milliseconds.